### PR TITLE
change return type of Signer::verification_method

### DIFF
--- a/src/jose/jws.rs
+++ b/src/jose/jws.rs
@@ -435,7 +435,7 @@ where
         let protected = Protected {
             alg: signer.algorithm(),
             typ: self.typ,
-            key: Key::KeyId(verification_method),
+            key: verification_method,
             ..Protected::default()
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod jose;
 use std::future::{Future, IntoFuture};
 
 use anyhow::Result;
+use jose::jws::Key;
 use serde::{Deserialize, Serialize};
 
 pub use crate::jose::jwa::Algorithm;
@@ -43,7 +44,7 @@ pub trait Signer: Send + Sync {
     ///
     /// Async and fallible because the client may need to access key information
     /// to construct the method reference.
-    fn verification_method(&self) -> impl Future<Output = Result<String>> + Send;
+    fn verification_method(&self) -> impl Future<Output = Result<Key>> + Send;
 }
 
 /// A Receiver (Recipient) is required to decrypt an encrypted message.


### PR DESCRIPTION
Return a Key enum from Signer trait verification_method() instead of a string so client has the option of a key ID or JWK